### PR TITLE
Rename polska to augska and j:polska to j:augska

### DIFF
--- a/data/CompliantSwitches/Junction/j:augska.toml
+++ b/data/CompliantSwitches/Junction/j:augska.toml
@@ -6,7 +6,7 @@ switch = true
 
 links = [
  'j:lexval',
- 'polska',
+ 'augska',
  #'j:lexrot',#future
  'j:covwes',
 ]

--- a/data/CompliantSwitches/Junction/j:covwes.toml
+++ b/data/CompliantSwitches/Junction/j:covwes.toml
@@ -7,5 +7,5 @@ switch = true
 links = [
  "j:westmore",
  "coventhia",
- "j:polska",
+ "j:augska",
 ]

--- a/data/CompliantSwitches/Junction/j:lexval.toml
+++ b/data/CompliantSwitches/Junction/j:lexval.toml
@@ -7,6 +7,6 @@ switch = true
 links = [
  'j:tel_aviv',
  'valyria',
- 'j:polska',
+ 'j:augska',
  'j:westmore',
 ]

--- a/data/TerminalDestinations/augska.toml
+++ b/data/TerminalDestinations/augska.toml
@@ -1,9 +1,9 @@
-aliases = ['augska']
+aliases = ['polska']
 
 x = -2808
 y = 7
 z = -7748
 
 links = [
- 'j:polska',
+ 'j:augska',
 ]


### PR DESCRIPTION
Reflects current name of settlement, earlier naming was in error.